### PR TITLE
drf_pagination_utils: Add Object Count Header Page Number pagination style

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ from rest_framework.settings import api_settings as drf_settings
 
 
 class StandardResultSetPagination(
+    fyntex.drf_pagination_utils.styles.ObjectCountHeaderPageNumberPagination,
     fyntex.drf_pagination_utils.styles.LinkHeaderPageNumberPagination,
 ):
     """
@@ -44,6 +45,8 @@ class StandardResultSetPagination(
     """
     Maximum page size the client may request.
     """
+
+    object_count_header: Optional[str] = 'X-Pagination-Total-Item-Count'
 ```
 
 Django settings:

--- a/fyntex/drf_pagination_utils/styles.py
+++ b/fyntex/drf_pagination_utils/styles.py
@@ -70,3 +70,29 @@ class LinkHeaderPageNumberPagination(rest_framework.pagination.PageNumberPaginat
         url = self.request.build_absolute_uri()
         result_url: str = remove_query_param(url, self.page_query_param)
         return result_url
+
+
+class ObjectCountHeaderPageNumberPagination(rest_framework.pagination.PageNumberPagination):
+    """
+    A simple page number–based style that adds a header with the total number of objects to
+    responses.
+    """
+
+    object_count_header: Optional[str] = None
+    """
+    Name of the response header that specifies the total number of objects.
+
+    If ``None``, no header will be added.
+    """
+
+    def get_paginated_response(self, data: object) -> DrfResponse:
+        response = super().get_paginated_response(data)
+
+        if self.page.has_other_pages():
+            self.add_object_count_header(response)
+
+        return response
+
+    def add_object_count_header(self, response: DrfResponse) -> None:
+        if self.object_count_header:
+            response[self.object_count_header] = self.page.paginator.count

--- a/fyntex/drf_pagination_utils/tests/test_styles.py
+++ b/fyntex/drf_pagination_utils/tests/test_styles.py
@@ -4,7 +4,7 @@ import unittest
 
 import rest_framework.pagination
 
-from ..styles import LinkHeaderPageNumberPagination
+from ..styles import LinkHeaderPageNumberPagination, ObjectCountHeaderPageNumberPagination
 
 
 class LinkHeaderPageNumberPaginationTest(unittest.TestCase):
@@ -21,6 +21,20 @@ class LinkHeaderPageNumberPaginationTest(unittest.TestCase):
         self.assertTrue(
             issubclass(
                 LinkHeaderPageNumberPagination,
+                rest_framework.pagination.PageNumberPagination,
+            ),
+        )
+
+
+class ObjectCountHeaderPageNumberPaginationTest(unittest.TestCase):
+    """
+    Tests for :class:`ObjectCountHeaderPageNumberPagination`.
+    """
+
+    def test_inherits_from_page_number_pagination_class(self) -> None:
+        self.assertTrue(
+            issubclass(
+                ObjectCountHeaderPageNumberPagination,
                 rest_framework.pagination.PageNumberPagination,
             ),
         )


### PR DESCRIPTION
- feat: Add Object Count Header Page Number pagination style
- chore: Update documentation

Sourced as is from:
- https://github.com/fyntex/fd-cl-data/blob/de402b3f1fec4f51a9d6efcdf24cd4064a32b352/fd_cl_data/libs/drf_pagination_utils.py
- https://github.com/fyntex/fd-cl-data/blob/de402b3f1fec4f51a9d6efcdf24cd4064a32b352/fd_cl_data/libs/tests/test_drf_pagination_utils.py

All the credit for these changes goes to @jtrobles-cdd 

Ref: https://cordada.aha.io/features/PLATCORE-266
Ref: https://cordada.aha.io/requirements/PLATCORE-266-3

Resolve #2 