### PR TITLE
Add dependency groups to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ version: 2
 updates:
   - package-ecosystem: pip
     directory: /
+    groups:
+      development-dependencies:
+        dependency-type: development
     schedule:
       interval: monthly
     commit-message:
@@ -21,6 +24,9 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    groups:
+      production-dependencies:
+        dependency-type: production
     schedule:
       interval: monthly
     commit-message:


### PR DESCRIPTION
> Dependabot grouped updates are currently in beta and is subject to change.
>
> By default, Dependabot raises a single pull request for each dependency
> that needs to be updated to a newer version. You can use `groups` to
> create sets of dependencies (per package manager), so that Dependabot
> opens a single pull request to update multiple dependencies at the
> same time.

- Add group for development dependencies to Python dependencies.
- Add group for production dependencies to GitHub Actions dependencies.

Related documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups