### PR TITLE
Add Codecov repository upload token

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -42,6 +42,7 @@ jobs:
       - workflow_config
 
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   # -----END CI Job-----
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3.1.4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./test_reports/coverage/
           fail_ci_if_error: true
 


### PR DESCRIPTION
- Add parameter with Codecov repository upload token to `ci` workflow.
- Enable GitHub Actions secrets inheritance so that Codecov token can be passed from `ci-cd` to `ci` workflow.