### PR TITLE
deps: Update `cryptography` from 43.0.1 to 44.0.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ click==8.0.1
     # via black
 coverage==7.6.1
     # via -r requirements-dev.in
-cryptography==43.0.1
+cryptography==44.0.1
     # via secretstorage
 docutils==0.19
     # via readme-renderer


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/cryptography/44.0.1/)
- ~~[Release Notes]()~~
- [Changelog](https://cryptography.io/en/44.0.1/changelog/#v44-0-1) ([GitHub](https://github.com/pyca/cryptography/blob/44.0.1/CHANGELOG.rst#4401---2025-02-11))
- [Commits](https://github.com/pyca/cryptography/compare/43.0.1...44.0.1)

Fixes: https://github.com/cordada/drf-pagination-utils/security/dependabot/57