### PR TITLE
Change Black target version to match supported Python versions

### DIFF
--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -9,4 +9,4 @@
 include = '\.pyi?$'
 line-length = 100
 skip-string-normalization = true
-target-version = ['py39']
+target-version = ['py39', 'py310']


### PR DESCRIPTION
According to the `pyproject.toml` file, this library supports Python versions 3.9 and 3.10.