### PR TITLE
chore(deps): Restrict python version to <3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ version = "1.5.3"
 dependencies = [
   "djangorestframework>=3.10.3",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.9, <3.11"
 authors = [
   {name = "Fyntex TI SpA", email = "no-reply@fyntex.ai"},
 ]


### PR DESCRIPTION
- restrict python version to <3.11 to prevent not tested versions being selected at release

Ref: https://app.shortcut.com/cordada/story/20073/