### PR TITLE
Release v1.5.6

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 1.5.6 (2026-05-07)
+
+- (PR #298, 2026-05-07) fix release version
+
 ## 1.5.5 (2026-05-06)
 
 - (PR #295, 2026-05-06) chore(deps): Restrict python version to <3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fyntex-drf-pagination-utils"
-version = "1.5.3"
+version = "1.5.6"
 dependencies = [
   "djangorestframework>=3.10.3",
 ]


### PR DESCRIPTION
(PR https://github.com/cordada/drf-pagination-utils/pull/295, 2026-05-06) chore(deps): Restrict python version to <3.11
(PR https://github.com/cordada/drf-pagination-utils/pull/255, 2025-04-02) chore: Bump the development-dependencies group with 2 updates
(PR https://github.com/cordada/drf-pagination-utils/pull/256, 2025-04-02) chore: Bump setuptools from 75.8.2 to 78.1.0
(PR https://github.com/cordada/drf-pagination-utils/pull/260, 2025-05-14) chore: Bump django from 4.2.20 to 4.2.21
(PR https://github.com/cordada/drf-pagination-utils/pull/261, 2025-05-20) chore: Bump setuptools from 78.1.0 to 78.1.1
(PR https://github.com/cordada/drf-pagination-utils/pull/258, 2025-05-20) chore: Bump the production-dependencies group across 1 directory with 6 updates
(PR https://github.com/cordada/drf-pagination-utils/pull/265, 2025-06-09) chore: Bump django from 4.2.21 to 4.2.22
(PR https://github.com/cordada/drf-pagination-utils/pull/262, 2025-06-09) chore: Bump the production-dependencies group with 2 updates
(PR https://github.com/cordada/drf-pagination-utils/pull/266, 2025-06-09) chore: Bump requests from 2.32.2 to 2.32.4
(PR https://github.com/cordada/drf-pagination-utils/pull/268, 2025-06-30) deps: Update requests-toolbelt from 0.10.1 to 1.0.0
(PR https://github.com/cordada/drf-pagination-utils/pull/267, 2025-08-01) chore: Bump urllib3 from 1.26.19 to 2.5.0
(PR https://github.com/cordada/drf-pagination-utils/pull/282, 2025-12-15) chore: Bump django from 4.2.22 to 4.2.27
(PR https://github.com/cordada/drf-pagination-utils/pull/292, 2026-05-04) Drop support for Python 3.9
